### PR TITLE
fix the url and rename arm to x86 formula

### DIFF
--- a/Formula/nimble-x86.rb
+++ b/Formula/nimble-x86.rb
@@ -1,9 +1,9 @@
-class NimbleArm < Formula
+class NimbleX86 < Formula
   desc "NimbleEdge CLI: nimble - interface to NimbleEdge systems"
   homepage "https://www.nimbleedge.ai/"
-  url "https://github.com/NimbleEdge/nimblecli/releases/download/v0.1.1/nimblecli_osx_arm_v0.1.1.zip"
-  sha256 "2dbf48d2a8115746911f2b34de321e24d86340a9725f48c4e00878742c65e1a7"
   license "BSD-2-Clause"
+  url "https://github.com/NimbleEdge/nimblecli/releases/download/v0.1.1/nimblecli_osx_v0.1.1.zip"
+  sha256 "68666f69529e169979af521dc1b7cba03fb38e09bb52b65ae9df4263fcfc2fb5"
 
   def install
     bin.install "nimble"

--- a/Formula/nimble.rb
+++ b/Formula/nimble.rb
@@ -1,8 +1,8 @@
 class Nimble < Formula
   desc "NimbleEdge CLI: nimble - interface to NimbleEdge systems"
   homepage "https://www.nimbleedge.ai/"
-  url "https://github.com/NimbleEdge/nimblecli/releases/download/v0.1.1/nimblecli_osx_v0.1.1.zip"
-  sha256 "68666f69529e169979af521dc1b7cba03fb38e09bb52b65ae9df4263fcfc2fb5"
+  url "https://github.com/NimbleEdge/nimblecli/releases/download/v0.1.1/nimblecli_osx_arm_v0.1.1.zip"
+  sha256 "2dbf48d2a8115746911f2b34de321e24d86340a9725f48c4e00878742c65e1a7"
   license "BSD-2-Clause"
 
   def install


### PR DESCRIPTION
# Description

Fix formula mix ups and create nimble and nimble-x86 formula to install in arm and pre-arm devices 


## Type of change

- [X] Improvements
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changes proposed in this PR
- delete nimble-arm.
- create nimble-x86 for pre arm devices.
- update binary URL's.
## How Has This Been Tested?

## Checklist: 

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
